### PR TITLE
Change zipinfo command to unzip -Z

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -29,7 +29,7 @@ get_image() {
     trap "rm '$tempzip'" EXIT
 
     wget ${CERTCHECK} --progress=bar:force --output-document="$tempzip" "$IMAGE_URL"
-    for f in $(zipinfo -1 "$tempzip"); do
+    for f in $(unzip -Z -1 "$tempzip"); do
         ext="${f##*.}"
         file=$(basename $f)
         if [ "$ext" == image -o "$ext" == changes ]; then


### PR DESCRIPTION
Because zipinfo is not an usual cmd in MinGw. Consequently, it is harder to compile with pillar on windows.
See man unzip:
   -Z     zipinfo(1L)  mode.   If the first option on the command line is -Z, the remaining options are taken to be zipinfo(1L) options.  See the appropriate manual page for a description of these options.